### PR TITLE
[BE] 각 모듈별 Test Coverage 설정 (#266)

### DIFF
--- a/backend/app-cvi-admin/build.gradle
+++ b/backend/app-cvi-admin/build.gradle
@@ -3,3 +3,7 @@ jar { enabled = true }
 
 dependencies {
 }
+
+sonarqube {
+    skipProject = true
+}

--- a/backend/app-cvi-api/build.gradle
+++ b/backend/app-cvi-api/build.gradle
@@ -19,38 +19,49 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured:4.3.3'
 }
 
-jacocoTestCoverageVerification { // 코드 커버리지 측정항목 시행
-    def Qdomains = []
-
-    for (qPattern in "*.QA".."*.QZ") {
-        Qdomains.add(qPattern + "*")
+jacocoTestReport {
+    dependsOn test // 리포트가 만들어지기 전 테스트 실행되어야 한다.
+    reports {
+        html.enabled true
+        xml.enabled true
+        csv.enabled false
     }
 
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, // 리포트 결과에 제외시킬 디렉토리
+                    exclude: ['**/DataLoader*',
+                              '**/CentralVaccinationInformationApplication*',
+                              '**/DummyData*'])
+        }))
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification { // 코드 커버리지 측정항목 시행
     violationRules { // 위반 규칙
         rule {
             enabled = true
-            element = 'BUNDLE'
+            element = 'GROUP'
 
             limit {
-                counter = 'INSTRUCTION'
+                counter = 'METHOD'
                 value = 'COVEREDRATIO'
-                minimum = 0.00
+                minimum = 0.80
             }
 
             excludes = [
                     // 커버리지 제외할 클래스
                     '*.DataLoader*',
-                    '*.CviApplication*',
+                    '*.CentralVaccinationInformationApplication*',
                     '*.DummyData*',
-                    '*.KakaoProfile*',
-                    '*.NaverProfile*'
-            ] + Qdomains
+            ]
         }
     }
 }
 
 sonarqube {
     properties {
-        property "sonar.exclusions", "**/*Test*.*, **/Q*.java, **/*Doc*.java"
+        property "sonar.exclusions", "**/*Test*.*, **/Q*.java, **/*Doc*.java, **/CentralVaccinationInformationApplication.java, **/DataLoader.java, **/DummyData.java"
     }
 }

--- a/backend/app-cvi-api/src/test/java/com/cvi/service/CommentServiceTest.java
+++ b/backend/app-cvi-api/src/test/java/com/cvi/service/CommentServiceTest.java
@@ -152,7 +152,7 @@ public class CommentServiceTest {
         //then
         assertThatThrownBy(() -> commentService.updateComment(post.getId(), commentResponse.getId(), optionalAnotherUser, updateRequest))
             .isInstanceOf(UnAuthorizedException.class)
-            .hasMessage("다른 사용자의 게시글은 수정할 수 없습니다.입력 값: " + user.toString());
+            .hasMessage("다른 사용자의 댓글은 수정할 수 없습니다.입력 값: " + user.toString());
     }
 
     @DisplayName("댓글 삭제 - 성공")

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id 'application'
 }
 
+
 application {
     mainClass = 'com.cvi.CentralVaccinationInformationApplication'
 }
@@ -21,7 +22,7 @@ subprojects {
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'jacoco'
-    apply plugin: 'org.sonarqube'
+    apply plugin: "org.sonarqube"
 
     group = 'com.backjoongwon'
     version = '0.0.1-SNAPSHOT'
@@ -57,32 +58,6 @@ subprojects {
         finalizedBy 'jacocoTestReport' // 테스트가 먼저 실행되고 리포트가 작동된다.
     }
 
-    jacocoTestReport {
-        dependsOn test // 리포트가 만들어지기 전 테스트 실행되어야 한다.
-        reports {
-            html.enabled true
-            xml.enabled true
-            csv.enabled false
-        }
-
-        def Qdomains = []
-        for (qPattern in "**/QA".."**/QZ") {
-            Qdomains.add(qPattern + "*")
-        }
-
-        afterEvaluate {
-            classDirectories.setFrom(files(classDirectories.files.collect {
-                fileTree(dir: it, // 리포트 결과에 제외시킬 디렉토리
-                        exclude: ['**/DataLoader*',
-                                  '**/CviApplication*',
-                                  '**/DummyData*',
-                                  '**/KakaoProfile*',
-                                  '**/NaverProfile*'] + Qdomains)
-            }))
-        }
-        finalizedBy 'jacocoTestCoverageVerification'
-    }
-
     /**
      * Sonar 관련 설정
      */
@@ -92,10 +67,6 @@ subprojects {
             property "sonar.tests", "src/test/java"
         }
     }
-
-/*    tasks.named('sonarqube').configure {
-        dependsOn jacocoTestCoverageVerification
-    }*/
 }
 
 def queryDslProjects = [project(':domain-cvi')]

--- a/backend/common-cvi/build.gradle
+++ b/backend/common-cvi/build.gradle
@@ -4,3 +4,7 @@ jar { enabled = true }
 dependencies {
 
 }
+
+sonarqube {
+    skipProject = true
+}

--- a/backend/cvi-publicdata-parser/build.gradle
+++ b/backend/cvi-publicdata-parser/build.gradle
@@ -16,38 +16,44 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:3.11.2'
 }
 
-jacocoTestCoverageVerification { // 코드 커버리지 측정항목 시행
-    def Qdomains = []
-
-    for (qPattern in "*.QA".."*.QZ") {
-        Qdomains.add(qPattern + "*")
+jacocoTestReport {
+    dependsOn test // 리포트가 만들어지기 전 테스트 실행되어야 한다.
+    reports {
+        html.enabled true
+        xml.enabled true
+        csv.enabled false
     }
 
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, // 리포트 결과에 제외시킬 디렉토리
+                    exclude: '**/Parser*')
+        }))
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification { // 코드 커버리지 측정항목 시행
     violationRules { // 위반 규칙
         rule {
             enabled = true
-            element = 'BUNDLE'
+            element = 'GROUP'
 
             limit {
-                counter = 'INSTRUCTION'
+                counter = 'METHOD'
                 value = 'COVEREDRATIO'
                 minimum = 0.80
             }
 
             excludes = [
                     // 커버리지 제외할 클래스
-                    '*.DataLoader*',
-                    '*.CviApplication*',
-                    '*.DummyData*',
-                    '*.KakaoProfile*',
-                    '*.NaverProfile*'
-            ] + Qdomains
+                    '*.Parser*']
         }
     }
 }
 
 sonarqube {
     properties {
-        property "sonar.exclusions", "**/*Test*.*, **/Q*.java, **/*Doc*.java"
+        property "sonar.exclusions", "**/*Test*.*, **/Q*.java, **/*Doc*.java, **/Parser.java"
     }
 }

--- a/backend/domain-cvi-aws-s3-service/build.gradle
+++ b/backend/domain-cvi-aws-s3-service/build.gradle
@@ -6,38 +6,6 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
-jacocoTestCoverageVerification { // 코드 커버리지 측정항목 시행
-    def Qdomains = []
-
-    for (qPattern in "*.QA".."*.QZ") {
-        Qdomains.add(qPattern + "*")
-    }
-
-    violationRules { // 위반 규칙
-        rule {
-            enabled = true
-            element = 'BUNDLE'
-
-            limit {
-                counter = 'INSTRUCTION'
-                value = 'COVEREDRATIO'
-                minimum = 0.85
-            }
-
-            excludes = [
-                    // 커버리지 제외할 클래스
-                    '*.DataLoader*',
-                    '*.CviApplication*',
-                    '*.DummyData*',
-                    '*.KakaoProfile*',
-                    '*.NaverProfile*'
-            ] + Qdomains
-        }
-    }
-}
-
 sonarqube {
-    properties {
-        property "sonar.exclusions", "**/*Test*.*, **/Q*.java, **/*Doc*.java"
-    }
+    skipProject = true
 }

--- a/backend/domain-cvi-oauth-service/build.gradle
+++ b/backend/domain-cvi-oauth-service/build.gradle
@@ -8,38 +8,47 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
 }
 
-jacocoTestCoverageVerification { // 코드 커버리지 측정항목 시행
-    def Qdomains = []
-
-    for (qPattern in "*.QA".."*.QZ") {
-        Qdomains.add(qPattern + "*")
+jacocoTestReport {
+    dependsOn test // 리포트가 만들어지기 전 테스트 실행되어야 한다.
+    reports {
+        html.enabled true
+        xml.enabled true
+        csv.enabled false
     }
 
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, // 리포트 결과에 제외시킬 디렉토리
+                    exclude: ['**/KakaoProfile*',
+                              '**/NaverProfile*'])
+        }))
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification { // 코드 커버리지 측정항목 시행
     violationRules { // 위반 규칙
         rule {
             enabled = true
-            element = 'BUNDLE'
+            element = 'GROUP'
 
             limit {
-                counter = 'INSTRUCTION'
+                counter = 'METHOD'
                 value = 'COVEREDRATIO'
                 minimum = 0.85
             }
 
             excludes = [
                     // 커버리지 제외할 클래스
-                    '*.DataLoader*',
-                    '*.CviApplication*',
-                    '*.DummyData*',
                     '*.KakaoProfile*',
                     '*.NaverProfile*'
-            ] + Qdomains
+            ]
         }
     }
 }
 
 sonarqube {
     properties {
-        property "sonar.exclusions", "**/*Test*.*, **/Q*.java, **/*Doc*.java"
+        property "sonar.exclusions", "**/*Test*.*, **/Q*.java, **/*Doc*.java, **/KakaoProfile.java, **/NaverProfile.java"
     }
 }

--- a/backend/domain-cvi-publicdata-service/build.gradle
+++ b/backend/domain-cvi-publicdata-service/build.gradle
@@ -6,32 +6,34 @@ dependencies {
     implementation project(path:':cvi-publicdata-parser', configuration: 'default')
 }
 
-jacocoTestCoverageVerification { // 코드 커버리지 측정항목 시행
-    def Qdomains = []
-
-    for (qPattern in "*.QA".."*.QZ") {
-        Qdomains.add(qPattern + "*")
+jacocoTestReport {
+    dependsOn test // 리포트가 만들어지기 전 테스트 실행되어야 한다.
+    reports {
+        html.enabled true
+        xml.enabled true
+        csv.enabled false
     }
 
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, // 리포트 결과에 제외시킬 디렉토리
+                    exclude: [])
+        }))
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification { // 코드 커버리지 측정항목 시행
     violationRules { // 위반 규칙
         rule {
             enabled = true
-            element = 'BUNDLE'
+            element = 'GROUP'
 
             limit {
-                counter = 'INSTRUCTION'
+                counter = 'METHOD'
                 value = 'COVEREDRATIO'
                 minimum = 0.90
             }
-
-            excludes = [
-                    // 커버리지 제외할 클래스
-                    '*.DataLoader*',
-                    '*.CviApplication*',
-                    '*.DummyData*',
-                    '*.KakaoProfile*',
-                    '*.NaverProfile*'
-            ] + Qdomains
         }
     }
 }

--- a/backend/domain-cvi-scheduler/build.gradle
+++ b/backend/domain-cvi-scheduler/build.gradle
@@ -6,38 +6,6 @@ dependencies {
 
 }
 
-jacocoTestCoverageVerification { // 코드 커버리지 측정항목 시행
-    def Qdomains = []
-
-    for (qPattern in "*.QA".."*.QZ") {
-        Qdomains.add(qPattern + "*")
-    }
-
-    violationRules { // 위반 규칙
-        rule {
-            enabled = true
-            element = 'BUNDLE'
-
-            limit {
-                counter = 'INSTRUCTION'
-                value = 'COVEREDRATIO'
-                minimum = 0.80
-            }
-
-            excludes = [
-                    // 커버리지 제외할 클래스
-                    '*.DataLoader*',
-                    '*.CviApplication*',
-                    '*.DummyData*',
-                    '*.KakaoProfile*',
-                    '*.NaverProfile*'
-            ] + Qdomains
-        }
-    }
-}
-
 sonarqube {
-    properties {
-        property "sonar.exclusions", "**/*Test*.*, **/Q*.java, **/*Doc*.java"
-    }
+    skipProject = true
 }

--- a/backend/domain-cvi/build.gradle
+++ b/backend/domain-cvi/build.gradle
@@ -13,6 +13,31 @@ dependencies {
 
 }
 
+jacocoTestReport {
+    dependsOn test // 리포트가 만들어지기 전 테스트 실행되어야 한다.
+    reports {
+        html.enabled true
+        xml.enabled true
+        csv.enabled false
+    }
+
+    def Qdomains = []
+    for (qPattern in "**/QA".."**/QZ") {
+        Qdomains.add(qPattern + "*")
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, // 리포트 결과에 제외시킬 디렉토리
+                    exclude: ['**/Sort*',
+                              '**/Filter*',
+                              '**/PostRepositoryImpl*',
+                              '**/ImageType*'] + Qdomains)
+        }))
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
 jacocoTestCoverageVerification { // 코드 커버리지 측정항목 시행
     def Qdomains = []
 
@@ -23,29 +48,27 @@ jacocoTestCoverageVerification { // 코드 커버리지 측정항목 시행
     violationRules { // 위반 규칙
         rule {
             enabled = true
-            element = 'BUNDLE'
+            element = 'GROUP'
 
             limit {
-                counter = 'INSTRUCTION'
+                counter = 'METHOD'
                 value = 'COVEREDRATIO'
                 minimum = 0.00
             }
 
             excludes = [
                     // 커버리지 제외할 클래스
-                    '*.DataLoader*',
-                    '*.CviApplication*',
-                    '*.DummyData*',
-                    '*.KakaoProfile*',
-                    '*.NaverProfile*'
+                    '*.Sort*',
+                    '*.Filter*',
+                    '*.PostRepository*',
+                    '*.ImageType.java*',
             ] + Qdomains
         }
     }
 }
 
-
 sonarqube {
     properties {
-        property "sonar.exclusions", "**/*Test*.*, **/Q*.java, **/*Doc*.java"
+        property "sonar.exclusions", "**/*Test*.*, **/Q*.java, **/*Doc*.java, **/DataLoader.java, **/Sort.java, **/Filter.java, **/PostRepositoryImpl.java, **/ImageType.java"
     }
 }

--- a/backend/domain-cvi/src/main/java/com/cvi/comment/domain/model/Comment.java
+++ b/backend/domain-cvi/src/main/java/com/cvi/comment/domain/model/Comment.java
@@ -72,8 +72,8 @@ public class Comment extends BaseEntity {
 
     public void update(Comment updateComment, User user) {
         if (!isSameUser(user)) {
-            log.info("다른 사용자의 게시글은 수정할 수 없습니다.입력 값: {}", this.user);
-            throw new UnAuthorizedException(String.format("다른 사용자의 게시글은 수정할 수 없습니다.입력 값: %s", this.user));
+            log.info("다른 사용자의 댓글은 수정할 수 없습니다. 입력 값: {}", this.user);
+            throw new UnAuthorizedException(String.format("다른 사용자의 댓글은 수정할 수 없습니다.입력 값: %s", this.user));
         }
         this.content = updateComment.content;
     }

--- a/backend/domain-cvi/src/test/java/com/cvi/comment/domain/model/CommentTest.java
+++ b/backend/domain-cvi/src/test/java/com/cvi/comment/domain/model/CommentTest.java
@@ -63,13 +63,23 @@ class CommentTest {
         assertThat(comment.getPost()).isEqualTo(post);
     }
 
-    @DisplayName("게시글 할당 - 실패")
+    @DisplayName("게시글 할당 - 실패 - 게시글이 없는 경우")
     @Test
     void assignPostFailure() {
         //given
         //when
         //then
         assertThatThrownBy(() -> comment.assignPost(null)).isInstanceOf(NotFoundException.class);
+    }
+
+    @DisplayName("게시글 할당 - 실패 - 이미 게시글에 할당된 경우")
+    @Test
+    void assignPostFailureWhenAlreadyAssignedPost() {
+        //given
+        //when
+        comment.assignPost(post);
+        //then
+        assertThatThrownBy(() -> comment.assignPost(post)).isInstanceOf(InvalidOperationException.class);
     }
 
     @DisplayName("유저 할당 - 성공")

--- a/backend/domain-cvi/src/test/java/com/cvi/comment/domain/repository/CommentRepositoryTest.java
+++ b/backend/domain-cvi/src/test/java/com/cvi/comment/domain/repository/CommentRepositoryTest.java
@@ -1,0 +1,128 @@
+package com.cvi.comment.domain.repository;
+
+import com.cvi.comment.domain.model.Comment;
+import com.cvi.image.domain.Image;
+import com.cvi.post.domain.model.Post;
+import com.cvi.post.domain.model.VaccinationType;
+import com.cvi.post.domain.repository.PostRepository;
+import com.cvi.user.domain.model.AgeRange;
+import com.cvi.user.domain.model.SocialProvider;
+import com.cvi.user.domain.model.User;
+import com.cvi.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CommentRepository 테스트")
+@DataJpaTest
+class CommentRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    private User user1;
+    private User user2;
+    private Comment comment1;
+    private Comment comment2;
+    private Comment comment3;
+    private Post post1;
+
+    @BeforeEach
+    void setUp() {
+        initUsers();
+        initPost();
+        initComments();
+        assertIdAssigned();
+    }
+
+    private void initUsers() {
+        user1 = User.builder()
+                .nickname("인비")
+                .ageRange(AgeRange.TEENS)
+                .socialProvider(SocialProvider.KAKAO)
+                .socialId("1000")
+                .profileUrl("profile url 1")
+                .build();
+        user2 = User.builder()
+                .nickname("검프")
+                .ageRange(AgeRange.FIFTIES)
+                .socialProvider(SocialProvider.NAVER)
+                .socialId("1001")
+                .profileUrl("profile url 2")
+                .build();
+        userRepository.save(user1);
+        userRepository.save(user2);
+    }
+
+    private void initPost() {
+        post1 = Post.builder()
+                .user(user1)
+                .content("내용 1")
+                .vaccinationType(VaccinationType.PFIZER)
+                .build();
+        postRepository.save(post1);
+    }
+
+    private void initComments() {
+        comment1 = Comment.builder()
+                .content("댓글 내용1")
+                .user(user1)
+                .build();
+        comment1.assignPost(post1);
+        commentRepository.save(comment1);
+
+        comment2 = Comment.builder()
+                .content("댓글 내용2")
+                .user(user2)
+                .build();
+        comment2.assignPost(post1);
+        commentRepository.save(comment2);
+
+        comment3 = Comment.builder()
+                .content("댓글 내용3")
+                .user(user2)
+                .build();
+        comment3.assignPost(post1);
+        commentRepository.save(comment3);
+    }
+
+    private void assertIdAssigned() {
+        assertThat(comment1.getId()).isNotNull();
+        assertThat(comment2.getId()).isNotNull();
+        assertThat(comment3.getId()).isNotNull();
+
+        assertThat(post1.getId()).isNotNull();
+    }
+
+    @DisplayName("유저 아이디로 댓글을 조회한다.")
+    @Test
+    void findCommentByUserId() {
+        //given
+        //when
+        //then
+        assertThat(commentRepository.findByUserId(user1.getId())).hasSize(1);
+        assertThat(commentRepository.findByUserId(user2.getId())).hasSize(2);
+    }
+
+    @DisplayName("유저 아이디로 댓글을 페이징 조회한다.")
+    @Test
+    void findCommentByUserIdPaging() {
+        //given
+        //when
+        //then
+        assertThat(commentRepository.findByUserId(user1.getId(), 0, 2)).hasSize(1);
+        assertThat(commentRepository.findByUserId(user2.getId(), 0, 2)).hasSize(2);
+    }
+}

--- a/backend/domain-cvi/src/test/java/com/cvi/image/model/ImageTest.java
+++ b/backend/domain-cvi/src/test/java/com/cvi/image/model/ImageTest.java
@@ -1,4 +1,4 @@
-package com.cvi.image;
+package com.cvi.image.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/backend/domain-cvi/src/test/java/com/cvi/image/repository/ImageRepositoryTest.java
+++ b/backend/domain-cvi/src/test/java/com/cvi/image/repository/ImageRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.cvi.image;
+package com.cvi.image.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/backend/domain-cvi/src/test/java/com/cvi/like/domain/model/LikeTest.java
+++ b/backend/domain-cvi/src/test/java/com/cvi/like/domain/model/LikeTest.java
@@ -1,7 +1,10 @@
 package com.cvi.like.domain.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.cvi.exception.InvalidOperationException;
+import com.cvi.exception.NotFoundException;
 import com.cvi.post.domain.model.Post;
 import com.cvi.post.domain.model.VaccinationType;
 import com.cvi.user.domain.model.AgeRange;
@@ -12,7 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("댓글 도메인 테스트")
+@DisplayName("좋아요 도메인 테스트")
 class LikeTest {
 
     private Post post;
@@ -47,6 +50,25 @@ class LikeTest {
         like.assignPost(post);
         //then
         assertThat(like.getPost()).isEqualTo(post);
+    }
+
+    @DisplayName("게시글 할당 - 실패 - 게시글이 없는 경우")
+    @Test
+    void assignPostFailure() {
+        //given
+        //when
+        //then
+        assertThatThrownBy(() -> like.assignPost(null)).isInstanceOf(NotFoundException.class);
+    }
+
+    @DisplayName("게시글 할당 - 실패 - 이미 게시글에 할당된 경우")
+    @Test
+    void assignPostFailureWhenAlreadyAssignedPost() {
+        //given
+        //when
+        like.assignPost(post);
+        //then
+        assertThatThrownBy(() -> like.assignPost(post)).isInstanceOf(InvalidOperationException.class);
     }
 
     @DisplayName("좋아요 누른 유저인지 확인")

--- a/backend/domain-cvi/src/test/java/com/cvi/like/domain/repository/LikeRepositoryTest.java
+++ b/backend/domain-cvi/src/test/java/com/cvi/like/domain/repository/LikeRepositoryTest.java
@@ -1,0 +1,132 @@
+package com.cvi.like.domain.repository;
+
+import com.cvi.comment.domain.model.Comment;
+import com.cvi.comment.domain.repository.CommentRepository;
+import com.cvi.like.domain.model.Like;
+import com.cvi.post.domain.model.Post;
+import com.cvi.post.domain.model.VaccinationType;
+import com.cvi.post.domain.repository.PostRepository;
+import com.cvi.user.domain.model.AgeRange;
+import com.cvi.user.domain.model.SocialProvider;
+import com.cvi.user.domain.model.User;
+import com.cvi.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("LikeRepository 테스트")
+@DataJpaTest
+class LikeRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    private User user1;
+    private User user2;
+    private Like like1;
+    private Like like2;
+    private Like like3;
+    private Post post1;
+    private Post post2;
+
+    @BeforeEach
+    void setUp() {
+        initUsers();
+        initPost();
+        initLikes();
+        assertIdAssigned();
+    }
+
+    private void initUsers() {
+        user1 = User.builder()
+                .nickname("인비")
+                .ageRange(AgeRange.TEENS)
+                .socialProvider(SocialProvider.KAKAO)
+                .socialId("1000")
+                .profileUrl("profile url 1")
+                .build();
+        user2 = User.builder()
+                .nickname("검프")
+                .ageRange(AgeRange.FIFTIES)
+                .socialProvider(SocialProvider.NAVER)
+                .socialId("1001")
+                .profileUrl("profile url 2")
+                .build();
+        userRepository.save(user1);
+        userRepository.save(user2);
+    }
+
+    private void initPost() {
+        post1 = Post.builder()
+                .user(user1)
+                .content("내용 1")
+                .vaccinationType(VaccinationType.PFIZER)
+                .build();
+        post2 = Post.builder()
+                .user(user1)
+                .content("내용 2")
+                .vaccinationType(VaccinationType.JANSSEN)
+                .build();
+        postRepository.save(post1);
+        postRepository.save(post2);
+    }
+
+    private void initLikes() {
+        like1 = Like.builder()
+                .user(user1)
+                .build();
+        like1.assignPost(post1);
+        likeRepository.save(like1);
+
+        like2 = Like.builder()
+                .user(user2)
+                .build();
+        like2.assignPost(post1);
+        likeRepository.save(like2);
+
+        like3 = Like.builder()
+                .user(user2)
+                .build();
+        like3.assignPost(post2);
+        likeRepository.save(like3);
+    }
+
+    private void assertIdAssigned() {
+        assertThat(like1.getId()).isNotNull();
+        assertThat(like2.getId()).isNotNull();
+        assertThat(like3.getId()).isNotNull();
+
+        assertThat(post1.getId()).isNotNull();
+    }
+
+    @DisplayName("유저 아이디로 좋아요를 조회한다.")
+    @Test
+    void findCommentByUserId() {
+        //given
+        //when
+        //then
+        assertThat(likeRepository.findByUserId(user1.getId())).hasSize(1);
+        assertThat(likeRepository.findByUserId(user2.getId())).hasSize(2);
+    }
+
+    @DisplayName("유저 아이디로 좋아요를 페이징 조회한다.")
+    @Test
+    void findCommentByUserIdPaging() {
+        //given
+        //when
+        //then
+        assertThat(likeRepository.findByUserId(user1.getId(), 0, 2)).hasSize(1);
+        assertThat(likeRepository.findByUserId(user2.getId(), 0, 2)).hasSize(2);
+    }
+}

--- a/backend/domain-cvi/src/test/java/com/cvi/post/domain/model/PostTest.java
+++ b/backend/domain-cvi/src/test/java/com/cvi/post/domain/model/PostTest.java
@@ -7,6 +7,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.cvi.comment.domain.model.Comment;
 import com.cvi.exception.InvalidOperationException;
 import com.cvi.exception.NotFoundException;
+import com.cvi.exception.UnAuthorizedException;
+import com.cvi.image.domain.Image;
+import com.cvi.like.domain.model.Like;
 import com.cvi.user.domain.model.AgeRange;
 import com.cvi.user.domain.model.SocialProvider;
 import com.cvi.user.domain.model.User;
@@ -27,6 +30,9 @@ class PostTest {
 
     private User user;
     private Post post;
+    private Comment comment;
+    private Like like;
+    private Image image;
 
     @BeforeEach
     void init() {
@@ -43,6 +49,19 @@ class PostTest {
             .socialProvider(SocialProvider.KAKAO)
             .createdAt(LocalDateTime.now())
             .build();
+        comment = Comment.builder()
+            .id(1L)
+            .content("댓글입니다.")
+            .user(user)
+            .build();
+        like = Like.builder()
+            .id(1L)
+            .user(user)
+            .build();
+        image = Image.builder()
+                .id(1L)
+                .url("image1_s3_url")
+                .build();
     }
 
     @DisplayName("게시글 작성자 할당 - 성공")
@@ -78,6 +97,122 @@ class PostTest {
         //then
         assertThatThrownBy(() -> post.assignUser(null))
             .isInstanceOf(NotFoundException.class);
+    }
+
+    @DisplayName("게시글 댓글 할당 - 성공")
+    @Test
+    void assignComment() {
+        //given
+        //when
+        post.assignComment(comment);
+        //then
+        assertThat(post.getComments().getComments()).hasSize(1);
+    }
+
+    @DisplayName("게시글 댓글 할당 - 실패 - 댓글에 할당된 게시글이 존재함")
+    @Test
+    void assignCommentFailureWhenAlreadyExists() {
+        //given
+        //when
+        post.assignComment(comment);
+        //then
+        assertThatThrownBy(() -> post.assignComment(comment))
+                .isInstanceOf(InvalidOperationException.class);
+    }
+
+    @DisplayName("게시글 댓글 할당 - 실패 - 할당하려는 댓글이 없음")
+    @Test
+    void assignCommentFailureWhenNull() {
+        //given
+        //when
+        //then
+        assertThatThrownBy(() -> post.assignComment(null))
+            .isInstanceOf(NotFoundException.class);
+    }
+
+    @DisplayName("게시글 좋아요 할당 - 성공")
+    @Test
+    void assignLike() {
+        //given
+        //when
+        post.assignLike(like);
+        //then
+        assertThat(post.getLikesCount()).isEqualTo(1);
+    }
+
+    @DisplayName("게시글 댓글 할당 - 실패 - 댓글에 할당된 게시글이 존재함")
+    @Test
+    void assignLikeFailureWhenAlreadyExists() {
+        //given
+        //when
+        post.assignLike(like);
+        //then
+        assertThatThrownBy(() -> post.assignLike(like))
+                .isInstanceOf(InvalidOperationException.class);
+    }
+
+    @DisplayName("게시글 댓글 할당 - 실패 - 할당하려는 댓글이 없음")
+    @Test
+    void assignLikeFailureWhenNull() {
+        //given
+        //when
+        //then
+        assertThatThrownBy(() -> post.assignLike(null))
+            .isInstanceOf(NotFoundException.class);
+    }
+
+    @DisplayName("게시글 댓글 수정")
+    @Test
+    void updateComment() {
+        //given
+        Comment updateComment = Comment.builder()
+                .content("수정된 댓글입니다.")
+                .user(user)
+                .build();
+        //when
+        post.assignComment(comment);
+        post.updateComment(1L, updateComment, user);
+        //then
+        assertThat(post.getCommentsAsList().get(0).getContent()).isEqualTo(updateComment.getContent());
+    }
+
+    @DisplayName("게시글 댓글 수정 - 실패 - 다른 사용자의 댓글을 수정할 수 없음")
+    @Test
+    void updateCommentFailure() {
+        //given
+        User anotherUser = User.builder()
+                .id(2L)
+                .nickname("다른유저")
+                .build();
+        Comment updateComment = Comment.builder()
+                .content("수정된 댓글입니다.")
+                .user(user)
+                .build();
+        //when
+        post.assignComment(comment);
+        //then
+        assertThatThrownBy(() -> post.updateComment(1L, updateComment, anotherUser))
+            .isInstanceOf(UnAuthorizedException.class);
+    }
+
+    @DisplayName("게시글 사진 할당 - 성공")
+    @Test
+    void assignImage() {
+        //given
+        //when
+        post.assignImages(Arrays.asList(image));
+        //then
+        assertThat(post.getAllImagesAsList()).hasSize(1);
+    }
+
+    @DisplayName("게시글 사진 할당 - 실패 - 사진이 존재하지 않음")
+    @Test
+    void assignImagesFailureWhenAlreadyExists() {
+        //given
+        //when
+        //then
+        assertThatThrownBy(() -> post.assignImages(Collections.emptyList()))
+                .isInstanceOf(NotFoundException.class);
     }
 
     @DisplayName("게시글 조회수 증가 - 성공")

--- a/backend/domain-cvi/src/test/java/com/cvi/publicdata/domain/model/VaccinationStatisticTest.java
+++ b/backend/domain-cvi/src/test/java/com/cvi/publicdata/domain/model/VaccinationStatisticTest.java
@@ -64,7 +64,7 @@ class VaccinationStatisticTest {
         assertThat(accumulatedSecondRate.doubleValue()).isEqualTo(actual);
     }
 
-    @ParameterizedTest(name = "인구수 비례 2차 접종률 계산 - 성공 - 잔세계")
+    @ParameterizedTest(name = "인구수 비례 2차 접종률 계산 - 성공 - 전세계")
     @CsvSource({
             "1153697698, 14.6",
             "1175939230, 14.9",


### PR DESCRIPTION
#266 

Comment, Like, Post, Image 클래스 등 도메인 클래스의 부족한 테스트 커버리지를 높이기 위해 테스트를 추가했습니다.

그럼에도 sonarqube 리포트 작성시 아래와 같은 테스트 커버리지를 보여주고 있었습니다.

![image](https://user-images.githubusercontent.com/48986787/133225993-fa010378-2f9f-4b4c-807d-2fdce77d6f59.png)



이를 해결하기 위해 각 모듈의 build.gradle 파일을 수정했습니다. 

수정 사항은 다음과 같습니다. 

1. **모듈 별 jacocoTestReport 설정**

기존에는 root 프로젝트의 build.gradle 파일에서 subprojects {} 내부에 jacocoTestReport 관련 설정이 포함되어 있었습니다.

root 프로젝트에서 jacocoTestReport 설정을 관리하게 되는 경우 리포트에서 제외하려는 모든 클래스 파일들이 root 프로젝트에서 관리됐기 때문에 멀티모듈을 적용한 의미가 없다고 생각했습니다. 

그래서 subprojects {}에 있던 jacocoTestReport 관련 설정들을 각 모듈별로 다르게 설정해 멀티모듈에 적합하게 적용해봤습니다.


<img width="998" alt="스크린샷 2021-10-05 오후 10 32 00" src="https://user-images.githubusercontent.com/67272922/136040118-2f9419be-4705-4a3a-9f2a-ffb7fc82eaf5.png">


<img width="761" alt="스크린샷 2021-10-05 오후 10 33 29" src="https://user-images.githubusercontent.com/67272922/136040162-1098cb22-02e2-4fd4-96e7-754ae3d6d68c.png">


2. **sonarqube 관련 설정**

app-cvi-admin, common-cvi, domain-cvi-scheduler 모듈은 테스트가 없어 jacocoTestReport 반영이 안되기 때문에 sonarqube 분석도 적용될 필요가 없었는데요. 이를 위해 정적 분석이 필요 없는 모듈의 경우 다음과 같은 설정을 추가해 소나큐브의 분석을 받지 않도록 설정했습니다. 


<img width="302" alt="스크린샷 2021-10-05 오후 10 40 23" src="https://user-images.githubusercontent.com/67272922/136040334-c99ec019-ae23-4f79-98c5-91bb85382eb2.png">


jacocoReport를 바탕으로 소나큐브가 정적 분석을 하는 거로 알았는데, 리포트 결과에서 제외해놓은 클래스들도 소나큐브에 추가가 되어 있더라구요? 커버리지 0%로...


<img width="1521" alt="스크린샷 2021-10-05 오후 10 45 43" src="https://user-images.githubusercontent.com/67272922/136040450-76dbb1e6-8c4d-4afe-b2b5-e5db1948913a.png">


그래서 각 모듈에서 sonarqube 설정으로 정적 분석 되지 않도록 설정했습니다. 


<img width="1522" alt="스크린샷 2021-10-05 오후 11 15 02" src="https://user-images.githubusercontent.com/67272922/136040814-24612ed8-0566-4eca-a50b-16ca60864e2b.png">


<img width="1543" alt="스크린샷 2021-10-05 오후 10 52 26" src="https://user-images.githubusercontent.com/67272922/136040643-442bdc9f-f15a-4b3f-afe2-081598eb8620.png">


외부 API 사용으로 테스트가 불가능한 클래스 같은 경우 분석될 필요가 없다면 설정을 위와 같이 하면 될 것 같습니다.



그리고 jacocotestCoverageVerification 부분에서 element를 BUNDLE -> GROUP으로 수정했습니다. 번들은 전체 패키지, GROUP은 논리적 번들 그룹이라고 합니다. https://www.eclemma.org/jacoco/trunk/doc/api/org/jacoco/core/analysis/ICoverageNode.ElementType.html


domain-cvi 모듈에 BUNDLE 적용시 테스트커버리지가 0.67 GROUP으로 적용시 80을 넘기기에 

멀티모듈에 적용하는 건 GROUP인 듯 싶어 GROUP으로 변경했습니다. 


**모듈별 주요 변경 사항**

## app-cvi-admin, common-cvi, domain-cvi-aws-s3-service, domain-cvi-scheduler

sonarqube { skipProject = true } 적용



## app-cvi-api

CentralVaccinationInformationApplication, DataLoader, DummyData 클래스 파일 리포트 결과, 커버리지, 소나큐브 분석 제외



## cvi-publicdata-parser

Parser 클래스 파일 리포트 결과, 커버리지, 소나큐브 분석 제외



## domain-cvi

Sort, Filter, PostRepository, ImageType 클래스 파일 리포트 결과, 커버리지 소나큐브 분석 제외



## domain-cvi-oauth-service

KakaoProfile, NaverProfile 클래스 파일 리포트 결과, 커버리지, 소나큐브 분석 제외