### PR TITLE
[FE] main 브랜치 cicd (#322)

### DIFF
--- a/.github/workflows/front-main-deploy.yml
+++ b/.github/workflows/front-main-deploy.yml
@@ -1,0 +1,31 @@
+name: front-main-deploy
+
+on:
+  push: # 적용될 액션
+    branches: main # 적용될 브랜치
+    paths:
+      - "frontend/**" # workflow에서 적용될 path
+
+defaults:
+  run:
+    working-directory: ./frontend # workflow에서 default working directory
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest # 인스턴스 OS
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2 # 워크플로에서 액세스할 수 있도록 에서 저장소를 체크아웃
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Build
+        run: yarn build
+
+      - name: S3 Deploy
+        run: aws s3 sync ./dist s3://2021-cvi/ --acl bucket-owner-full-control # s3 이름 2021-cvi
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
#322

1. AWS s3 2021-cvi의 객체를 변경하더라도 소유권을 계속 갖도록, 소유권 버킷 선호자로 변경
![image](https://user-images.githubusercontent.com/40762111/137065651-68e8b690-6a62-4d09-8ded-acba05be07e7.png)

2. AWS s3 엑세스 제어 목록에 github action에서 접근할 수 있도록 피부여자 추가
![image](https://user-images.githubusercontent.com/40762111/137065826-cd554622-6281-4b8d-ac1c-5787c472804c.png)

3. main에 push 될 경우 동작하는 script 작성 (front-main-deploy.yml)

확인 부탁드려요!